### PR TITLE
Add entry for Handprint in section on Handwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [vloison/Handwritten_Text_Recognition](https://github.com/vloison/Handwritten_Text_Recognition)
 - https://github.com/sushant097/Handwritten-Line-Text-Recognition-using-Deep-Learning-with-Tensorflow
 - https://github.com/qurator-spk/sbb_textline_detection
+- [Handprint](https://github.com/caltechlibrary/handprint) - apply HTR services from Amazon, Google, and/or Microsoft to scanned documents
 
 ## Table detection
 


### PR DESCRIPTION
At the risk of self promotion, I wanted to suggest the addition of an entry for Handprint to the section on handwritten text recognition.

Handprint (_**Hand**written **P**age **R**ecognit**i**o**n** **T**est_) is a command-line program that invokes HTR (handwritten text recognition) services on images of document pages. It can produce annotated images showing the results, compare the recognized text to expected text, save the HTR service results as JSON and text files, and more.